### PR TITLE
Task 1: Implement email validation and correct test Factory configuration

### DIFF
--- a/connections/models/person.py
+++ b/connections/models/person.py
@@ -1,4 +1,5 @@
 from connections.database import CreatedUpdatedMixin, CRUDMixin, db, Model
+from connections.models.connection import ConnectionType
 
 
 class Person(Model, CRUDMixin, CreatedUpdatedMixin):
@@ -9,3 +10,15 @@ class Person(Model, CRUDMixin, CreatedUpdatedMixin):
     date_of_birth = db.Column(db.Date, nullable=False)
 
     connections = db.relationship('Connection', foreign_keys='Connection.from_person_id')
+
+    def mutual_friends(self, contact):
+        """Given another person *contact*, return a set of people who are friends with both *self*
+        and *contact*."""
+
+        friends = [conn.to_person_id for conn in self.connections
+                   if conn.connection_type == ConnectionType.friend]
+        contact_fiends = [conn.to_person_id for conn in contact.connections
+                          if conn.connection_type == ConnectionType.friend]
+
+        return [db.session.query(Person).filter(Person.id == friend).first()
+                for friend in set(friends).intersection(set(contact_fiends))]

--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -12,6 +12,7 @@ class BaseModelSchema(ma.ModelSchema):
 
 
 class PersonSchema(BaseModelSchema):
+    email = fields.Email()
 
     class Meta:
         model = Person

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,4 +1,4 @@
-from factory import Faker, Sequence, SubFactory
+from factory import Faker, SelfAttribute, Sequence, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from connections.database import db
@@ -26,6 +26,7 @@ class PersonFactory(BaseFactory):
     class Meta:
 
         model = Person
+        force_flush = True
 
 
 class ConnectionFactory(BaseFactory):
@@ -33,9 +34,12 @@ class ConnectionFactory(BaseFactory):
 
     connection_type = 'friend'
 
+    from_person_id = SelfAttribute('from_person.id')
     from_person = SubFactory(PersonFactory)
+    to_person_id = SelfAttribute('to_person.id')
     to_person = SubFactory(PersonFactory)
 
     class Meta:
 
         model = Connection
+        exclude = ('from_person', 'to_person')

--- a/tests/functional/people/test_create_person.py
+++ b/tests/functional/people/test_create_person.py
@@ -39,8 +39,7 @@ def test_can_create_person(db, testapp, person_payload):
 @pytest.mark.parametrize('field, value, error_message', [
     pytest.param('first_name', None, 'Field may not be null.', id='missing first name'),
     pytest.param('email', None, 'Field may not be null.', id='missing email'),
-    pytest.param('email', 'foo@bar', 'Not a valid email address.', id='invalid email',
-                 marks=pytest.mark.xfail),
+    pytest.param('email', 'foo@bar', 'Not a valid email address.', id='invalid email'),
     pytest.param('date_of_birth', '0000-00-00', 'Not a valid date.', id='date of birth invalid'),
     pytest.param('date_of_birth', '4000-12-30', 'Cannot be in the future.', id='born in future',
                  marks=pytest.mark.xfail),

--- a/tests/units/test_person.py
+++ b/tests/units/test_person.py
@@ -1,8 +1,6 @@
-import pytest
 from tests.factories import ConnectionFactory, PersonFactory
 
 
-@pytest.mark.xfail
 def test_mutual_friends(db):
     instance = PersonFactory()
     target = PersonFactory()


### PR DESCRIPTION
> Run the tests and you will see that while most tests pass some are ‘xfail’, remove the ‘xfail’ decorator from the following tests and the build will fail. Using existing code as reference, add the necessary implementation to make the build pass.
> 
> - test_create_person.py - create_person_validations - “invalid email”
> - test_person.py - test_mutual_friends

-----


Successfully ran the tests, noted the xfails, removed them, and demonstrated the failures.

The task specified specific tests to fix.

ASSUMPTION: The tests are specified to ensure attention to detail. But just in case, I'll implement a sixth task that fixes the other tests.

The email validation was straightforward, given that I have some familiarity with SQLAlchemy.

Working on the second test "test_mutual_friends", and I'm not sure what's happening with it. The failure is that "from_person" isn't a keyword argument for the Connection type. It seems to me this should be a keyword argument, so perhaps that's where the problem is. However, I'm not certain I understand what the code is doing right now, for example I don't see where "from_person" is being passed in. So perhaps I don't understand the code. I'm going to ignore it for now and just try to fix the error on its face.

My initial attempt to fix was to simply change the inter-factory references from "from_person" and "to_person" to "from_person_id" and "to_person_id". This allowed the setup code to proceed, but it seems to not be making the connections properly. Going to investigate a bit more, but I may need a different approach. Curiously, it appears when I debug the test, the connections made by the test are not saved. Running the same commands and committing to the db again makes them appear...

So, adding a `db.session.commit()` at the beginning of the test means the connections are saved. I don't like it. I suspect the issue has to do with my fix attempt, that referencing the IDs, rather than the objects, prevents some kind of object generation, so IDs for `Persons` aren't generated as expected, and setting up connections fails.

Ok, so my next attempt is to use the ConnectionFactory to create dynamic "_id" attributes for "to_person" and "from_person", and exclude passing in the full object references. As I understand, this should create the users when the connection factory is called, then pass in references to the object IDs when creating the connections.

This allowed the code to complete, but we're still seeing issues with the database. 

Still having troubles with connections being maintained, adding factoryboy logging and switching to a simpler test. Having done that, it seems clear that I need to call `db.session.commit()` after creating the users that are being connected. It seems like I may not need to call it after using the factory to create the connections, at least for the purpose of the test, but that doesn't feel right.

I found something to flush the tables whenever a `Person` is created, which seems to have dealt with our more pressing issues here.  I'm sort of wondering whether lack of database flush was impeding SQLAlchemy in automatically mapping IDs, so I'll try it without that.... NOPE