### PR TITLE
Task 2: Add endpoints for retrieving and modifying connections

### DIFF
--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -26,6 +26,7 @@ class ConnectionSchema(BaseModelSchema):
     class Meta:
         model = Connection
 
+
 class ConnectionUpdateSchema(ConnectionSchema):
 
     class Meta:

--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -25,3 +25,9 @@ class ConnectionSchema(BaseModelSchema):
 
     class Meta:
         model = Connection
+
+class ConnectionUpdateSchema(ConnectionSchema):
+
+    class Meta:
+        model = Connection
+        exclude = ('from_person_id', 'to_person_id')

--- a/connections/views.py
+++ b/connections/views.py
@@ -67,6 +67,7 @@ def update_connection(connection_update, connection_id):
         connection.save()
         return '', HTTPStatus.NO_CONTENT
     except NoResultFound:
-        return jsonify({'description': 'Resource not found.',
-                        'errors': {'connection_id': ['No connection found with this ID']}}),
-        HTTPStatus.GONE
+        return (
+            jsonify({'description': 'Resource not found.',
+                     'errors': {'connection_id': ['No connection found with this ID']}}),
+            HTTPStatus.GONE)

--- a/connections/views.py
+++ b/connections/views.py
@@ -1,8 +1,9 @@
 from http import HTTPStatus
 
-from flask import Blueprint
+from flask import Blueprint, jsonify
 from webargs.flaskparser import use_args
 
+from connections.models.connection import Connection
 from connections.models.person import Person
 from connections.schemas import ConnectionSchema, PersonSchema
 
@@ -21,6 +22,24 @@ def get_people():
 def create_person(person):
     person.save()
     return PersonSchema().jsonify(person), HTTPStatus.CREATED
+
+
+@blueprint.route('/connections', methods=['GET'])
+def get_connections():
+    # TODO: is many needed here?
+    connection_schema = ConnectionSchema(many=True)
+    people_schema = PersonSchema(many=True)
+    connections = Connection.query.all()
+    person_json = lambda p: dict([(f, getattr(p, f)) for f in ['id', 'first_name', 'last_name', 'email']])
+
+    # It didn't seem to make sense to alter the schema just to get an expanded representation of a person
+    return jsonify(list({
+        'id': connection.id,
+        'from_person': person_json(Person.query.filter(Person.id==connection.from_person_id).one()),
+        'to_person': person_json(Person.query.filter(Person.id==connection.to_person_id).one()),
+        'connection_type': connection.connection_type.value
+    }
+    for connection in connections)), HTTPStatus.OK
 
 
 @blueprint.route('/connections', methods=['POST'])

--- a/tests/functional/connections/test_get_connections.py
+++ b/tests/functional/connections/test_get_connections.py
@@ -1,9 +1,10 @@
 from http import HTTPStatus
 
-from connections.models.connection import ConnectionType
 from tests.factories import ConnectionFactory, PersonFactory
 # Importing from other tests is usually fine, but only if they are all being run together
 from tests.functional.people.test_get_people import EXPECTED_FIELDS as EXPECTED_PERSON_FIELDS
+
+from connections.models.connection import ConnectionType
 
 EXPECTED_FIELDS = [
     'id',
@@ -30,7 +31,8 @@ def test_can_get_connections(db, testapp):
 def test_can_get_connection_people(db, testapp):
     from_person = PersonFactory()
     to_person = PersonFactory()
-    ConnectionFactory(from_person=from_person, to_person=to_person, connection_type=ConnectionType.friend)
+    ConnectionFactory(from_person=from_person, to_person=to_person,
+                      connection_type=ConnectionType.friend)
     db.session.commit()
 
     res = testapp.get('/connections')
@@ -39,7 +41,7 @@ def test_can_get_connection_people(db, testapp):
 
     # Because we're not currently tearing down between tests, this is 11
     assert len(res.json) == 11
-    
+
     connection = res.json[10]
 
     assert connection['from_person']['id'] == from_person.id

--- a/tests/functional/connections/test_get_connections.py
+++ b/tests/functional/connections/test_get_connections.py
@@ -1,0 +1,51 @@
+from http import HTTPStatus
+
+from connections.models.connection import ConnectionType
+from tests.factories import ConnectionFactory, PersonFactory
+# Importing from other tests is usually fine, but only if they are all being run together
+from tests.functional.people.test_get_people import EXPECTED_FIELDS as EXPECTED_PERSON_FIELDS
+
+EXPECTED_FIELDS = [
+    'id',
+    'from_person',
+    'to_person',
+    'connection_type',
+]
+
+
+def test_can_get_connections(db, testapp):
+    ConnectionFactory.create_batch(10)
+    db.session.commit()
+
+    res = testapp.get('/connections')
+
+    assert res.status_code == HTTPStatus.OK
+
+    assert len(res.json) == 10
+    for connection in res.json:
+        for field in EXPECTED_FIELDS:
+            assert field in connection
+
+
+def test_can_get_connection_people(db, testapp):
+    from_person = PersonFactory()
+    to_person = PersonFactory()
+    ConnectionFactory(from_person=from_person, to_person=to_person, connection_type=ConnectionType.friend)
+    db.session.commit()
+
+    res = testapp.get('/connections')
+
+    assert res.status_code == HTTPStatus.OK
+
+    # Because we're not currently tearing down between tests, this is 11
+    assert len(res.json) == 11
+    
+    connection = res.json[10]
+
+    assert connection['from_person']['id'] == from_person.id
+    assert connection['to_person']['id'] == to_person.id
+    assert connection['connection_type'] == ConnectionType.friend.value
+
+    for field in EXPECTED_PERSON_FIELDS:
+        assert field in connection['to_person']
+        assert field in connection['from_person']

--- a/tests/functional/connections/test_update_connection.py
+++ b/tests/functional/connections/test_update_connection.py
@@ -1,8 +1,6 @@
-from datetime import date
 from http import HTTPStatus
 
-import pytest
-from tests.factories import PersonFactory, ConnectionFactory
+from tests.factories import ConnectionFactory
 
 from connections.models.connection import Connection, ConnectionType
 
@@ -31,7 +29,7 @@ def test_bad_connection_id(db, testapp):
     res = testapp.patch(f'/connections/0', json=payload)
 
     assert res.status_code == HTTPStatus.GONE
-    assert res.json == {'description': 'Resource not found.', 
+    assert res.json == {'description': 'Resource not found.',
                         'errors': {'connection_id': ['No connection found with this ID']}}
 
 
@@ -39,12 +37,12 @@ def test_bad_connection_type(db, testapp):
     connection = ConnectionFactory(connection_type=ConnectionType.coworker)
     db.session.commit()
     payload = {
-        'connection_type': "godmother",
+        'connection_type': 'godmother',
     }
     res = testapp.patch(f'/connections/{connection.id}', json=payload)
 
     assert res.status_code == HTTPStatus.BAD_REQUEST
-    assert res.json == {'description': 'Input failed validation.', 
+    assert res.json == {'description': 'Input failed validation.',
                         'errors': {'connection_type': ['Invalid enum member godmother']}}
 
     new_connection = Connection.query.get(connection.id)

--- a/tests/functional/connections/test_update_connection.py
+++ b/tests/functional/connections/test_update_connection.py
@@ -1,0 +1,53 @@
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+from tests.factories import PersonFactory, ConnectionFactory
+
+from connections.models.connection import Connection, ConnectionType
+
+
+def test_can_update_connection(db, testapp):
+    connection = ConnectionFactory(connection_type=ConnectionType.coworker)
+    db.session.commit()
+    payload = {
+        'connection_type': ConnectionType.friend.value,
+    }
+    res = testapp.patch(f'/connections/{connection.id}', json=payload)
+
+    assert res.status_code == HTTPStatus.NO_CONTENT
+
+    connection = Connection.query.get(connection.id)
+
+    assert connection is not None
+    assert connection.connection_type == ConnectionType.friend
+
+
+def test_bad_connection_id(db, testapp):
+    payload = {
+        'connection_type': ConnectionType.friend.value,
+    }
+    # '0' seems like a safe integer value that should never be an ID
+    res = testapp.patch(f'/connections/0', json=payload)
+
+    assert res.status_code == HTTPStatus.GONE
+    assert res.json == {'description': 'Resource not found.', 
+                        'errors': {'connection_id': ['No connection found with this ID']}}
+
+
+def test_bad_connection_type(db, testapp):
+    connection = ConnectionFactory(connection_type=ConnectionType.coworker)
+    db.session.commit()
+    payload = {
+        'connection_type': "godmother",
+    }
+    res = testapp.patch(f'/connections/{connection.id}', json=payload)
+
+    assert res.status_code == HTTPStatus.BAD_REQUEST
+    assert res.json == {'description': 'Input failed validation.', 
+                        'errors': {'connection_type': ['Invalid enum member godmother']}}
+
+    new_connection = Connection.query.get(connection.id)
+
+    # Confirm it has not been updated
+    assert new_connection.updated_at == connection.updated_at


### PR DESCRIPTION
> Add 2 endpoints to the project:
> 
> - GET /connections
>   - Return all connections including full details for the people involved (id, first_name, last_name, email)  
>   - Add functional test(s) for this endpoint
> - PATCH /connections/<connection_id>
>   - Ability to change the connection_type of a connection (must validate that it is a supported type)
>   - Add functional test(s) for this endpoint

    
----

It was fairly straightforward to copy existing functionality for retrieving a Person and modify it for Connections. The only sticking point was expanding referenced people from ids into their full representations. I suspect there's a way to make it more standardized, somehow combining the schema formating from both `ConnectionSchema` and `PersonSchema`, but for the limited requirements of this task, it didn't seem worth spending time on that.

I added an additional test for the `/connections` endpoint, focusing on expanding the `Person` representations. We could perform all the assertions in a single test without that being a problem, but it felt like a natural place to add a test. That said, since these tests are generating data that persists between them, we would probably want to add a teardown to clean those up, so the individual tests can be independent.

Moving on to adding an endpoint to update `Connections`. It looks like the requirement is just to allow updating connection type, not who the connected people are, so I'm inclined to only accept a connection type as the body of the PATCH. That said, it looks like the standard for PATCH is to accept a list of changes, so I guess it's better if the body is a dictionary or list of field/value pairs. It's a little ambiguous from an API standpoint without some documentation to go with it, but for our purposes it's fine.

Implementing the above, I'm not sure immediately how to use webargs to parse the desired input. If there's a way I can specify that I want to match `ConnectionSchema` but skip two fields, that would do the trick. I'm trying that, apparently I definitely need to reference a class from the meta of my `ConnectionUpdateSchema`, and while using `exclude` does seem to allow the represenation to be passed in without those additional fields, they are still part of the representation passed to the PATCH function. So I'll create a list of updateable fields, and work off of that. I'm not sure the best place for that to live, putting it in `views.py` for now.

When working through, I'm using references to the ConnectionType enum whereever possible, instead of string values. This is a departure from the standards of the codebase, it seems, but would be a good thing to change throughout.